### PR TITLE
profiles/workstation: switch to using the new rbrowser

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1604441492,
-        "narHash": "sha256-Wo7WqdwNQnWHmhyZuhVLrAEpCuZl88cA9ttxkiCTekY=",
+        "lastModified": 1608691654,
+        "narHash": "sha256-czN7JI//CqTiz4uEBvzwT8pW/YUg8lcnCUgghzgsNCU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "63f299b3347aea183fc5088e4d6c4a193b334a41",
+        "rev": "2f6781b6be7f5dcbfb8ffa546387c30fc38b97b7",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1608588867,
-        "narHash": "sha256-laH1mNf1eMaQQC5v+YpC6onYOzWG9qsnPcknfP/NYu8=",
+        "lastModified": 1608841348,
+        "narHash": "sha256-39COmOLOFA4ASktDPBVv9qRoyJd1Pj4R3XCNHYrHZdc=",
         "owner": "SoxinOS",
         "repo": "soxin",
-        "rev": "a8f2179631e7b196dcd2eeecee8accfb76d9dba2",
+        "rev": "127bc12ec5db20dc4dd1985fd55f981b30b0b643",
         "type": "github"
       },
       "original": {

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -24,6 +24,7 @@ let
 
       specialArgs = {
         inherit nixos-hardware;
+        inherit (pkgset) nixpkgs-master;
         soxincfg = self;
       };
 
@@ -81,20 +82,11 @@ let
 
           sops-nix.nixosModules.sops
 
-          {
-            _module.args = {
-              inherit home-manager;
-              inherit (pkgset) nixpkgs-master;
-            };
-          }
-
           # This allows us to use our flake modules in NixOS and home-manager
           # configurations.
           {
             options.home-manager.users = lib.mkOption {
-              type = lib.types.attrsOf (lib.types.submoduleWith {
-                modules = flakeModules;
-              });
+              type = lib.types.attrsOf (lib.types.submoduleWith { modules = flakeModules; });
             };
           }
         ];

--- a/hosts/kore/configuration.nix
+++ b/hosts/kore/configuration.nix
@@ -67,7 +67,7 @@ in
   nix.trustedUsers = [ "root" "@wheel" "@builders" ];
   users.users = {
     builder = {
-      extraGroups = ["builders"];
+      extraGroups = [ "builders" ];
       openssh.authorizedKeys.keys = [
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDKBOvTyKSvp4vENrpyFKkZ+OfBBeSXRvR7CWhPBHbGD19Xev+gAF/D1y5zqdaEK6sZuSmWoBfLHatbfWjiz6Yj1uygYtDilyqSaw0tkdsOMihMHtqvkdNugrzPyfyeugdGUPG50tnXbkTyp8QOfxhkqdpwku0NMLMnMDMOKjGzdYlEFvdPANnjiS2FTrDRbTvb4B64t9OgQ0d/tUpuTMRvRSoTLBtlJC5nNFhNKnhDl6lZDMTQyTZSg8iA25W2C2KQVs5IKJ+E+LMS7golD3t1i/S9kN4guo7yoEU5lQ8xGBqDX5Gnqwl1wriKJP1roIS0tqi9yHCSX18oeyotY7Y3mWg5lIwotgOBYJ3X5IIH1L0oG92aK5dyGedoDUUMZ8GcRX98PqW8WUa0lZRaYyPfmpN5tzhJpKaqwtdKhxgMyESx0UUFTmUwPPgTVvd4gb0P989BguwKKggx591FzGOHVpWwoYcR9S4q+3F+bSzxKFAOet8CARPP2f3v3ULG6pjSycrvy16BMnzIr1kUmlzBQfhFhqa0HR6I9VQu1ND2SOZPz11wTE7zdOWMV68A47tvvemCOM9GSHLATbTeDnZNWwVAICUslkYiiLULTev07bh5OuwQfY+IK0IeCZ4Wsvy52nWz1YsVmLcwPqPCpsi0oqyhEFzBpfhMwATWlaSiQw== Kore Builder"
       ];

--- a/modules/programs/brave.nix
+++ b/modules/programs/brave.nix
@@ -9,7 +9,6 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     (optionalAttrs (mode == "home-manager") {
-      home.file.".config/brave/profiles/personal/.keep".text = "";
       home.packages = with pkgs; [ brave ];
     })
   ]);

--- a/modules/programs/chromium/default.nix
+++ b/modules/programs/chromium/default.nix
@@ -11,15 +11,6 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     (optionalAttrs (mode == "home-manager") {
-      home.file.".config/chromium/profiles/anya/.keep".text = "";
-      home.file.".config/chromium/profiles/ihab/.keep".text = "";
-      home.file.".config/chromium/profiles/keeptruckin/.keep".text = "";
-      home.file.".config/chromium/profiles/nosecurity/.keep".text = "";
-      home.file.".config/chromium/profiles/personal/.keep".text = "";
-      home.file.".config/chromium/profiles/vanya/.keep".text = "";
-
-      home.file.".config/chromium/profiles/nosecurity/.cmdline_args".text = "--disable-web-security";
-
       home.packages = with pkgs; [ chromium ];
     })
 

--- a/profiles/workstation/default.nix
+++ b/profiles/workstation/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, mode, pkgs, ... }:
+{ config, home-manager, lib, mode, pkgs, ... }:
 
 with lib;
 
@@ -29,9 +29,17 @@ mkMerge [
           enable = true;
           setMimeList = true;
           browsers = {
-            brave.enable = false;
-            chromium.enable = true;
-            firefox.enable = true;
+            "firefox@personal" = home-manager.lib.hm.dag.entryBefore [ "chromium@keeptruckin" ] { };
+            "chromium@keeptruckin" = home-manager.lib.hm.dag.entryBefore [ "brave@personal" ] { };
+            "firefox@keeptruckin" = home-manager.lib.hm.dag.entryAnywhere { };
+            "chromium@personal" = home-manager.lib.hm.dag.entryAnywhere { };
+            "chromium@anya" = home-manager.lib.hm.dag.entryAnywhere { };
+            "chromium@private" = home-manager.lib.hm.dag.entryAnywhere { };
+            "chromium@ihab" = home-manager.lib.hm.dag.entryAnywhere { };
+            "chromium@nosecurity" = home-manager.lib.hm.dag.entryAnywhere { flags = singleton "--disable-web-security"; };
+            "chromium@tanya" = home-manager.lib.hm.dag.entryAnywhere { };
+            "chromium@vanya" = home-manager.lib.hm.dag.entryAnywhere { };
+            "brave@personal" = home-manager.lib.hm.dag.entryAnywhere { };
           };
         };
         rofi.enable = true;


### PR DESCRIPTION
Use the new rbrowser to declare profiles and their custom flags.

TODO:
- [x] Update soxin input once https://github.com/SoxinOS/soxin/pull/18 is merged.