### PR TITLE
feat: Introduce ssh-agent-mux on top of keychain and secretive

### DIFF
--- a/hosts/darwins/saturn/darwin.nix
+++ b/hosts/darwins/saturn/darwin.nix
@@ -52,8 +52,14 @@
   # Determinate systems uses its own daemon and we shouldn't let nix-darwin manage Nix
   nix.enable = false;
 
-  # Enable Nix Distributed builds
-  soxincfg.settings.nix.distributed-builds.enable = true;
+  soxincfg = {
+    # Enable Nix Distributed builds
+    settings.nix.distributed-builds.enable = true;
+
+    # TODO: Move to the darwin workstation profile
+    programs.secretive.enable = true;
+    services.ssh-agent-mux.enable = true;
+  };
 
   # load home-manager configuration
   # TODO: Use users.user.name once the following commit is used

--- a/hosts/darwins/saturn/home.nix
+++ b/hosts/darwins/saturn/home.nix
@@ -15,6 +15,12 @@ in
     soxincfg.nixosModules.profiles.workstation.darwin.local
   ];
 
+  soxincfg = {
+    # TODO: Move to the darwin workstation profile
+    programs.secretive.enable = true;
+    services.ssh-agent-mux.enable = true;
+  };
+
   home.stateVersion = "24.11";
 
   sops = {

--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -46,12 +46,13 @@ let
             fluxcd
             hubble
             protonvpn-gui
+            secretive
             talosctl
             ;
         })
       ];
 
-      patches = [ ];
+      patches = [ ../patches/ssh-agent-mux.patch ];
     };
 
     nixpkgs-unstable = {

--- a/modules/hardware/onlykey/home.nix
+++ b/modules/hardware/onlykey/home.nix
@@ -69,14 +69,25 @@ in
 
     (mkIf (cfg.ssh-support.enable && pkgs.stdenv.hostPlatform.isDarwin) {
       programs.zsh.initContent = ''
-        if [[ -e "$HOME/.ssh/rc" ]]; then
-          (
-            eval "$(${pkgs.keychain}/bin/keychain --eval --agents ssh id_ed25519_sk_rk -q)"
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+          # Ensure XDG_RUNTIME_DIR is set on Darwin
+          if [[ -z "$XDG_RUNTIME_DIR" ]]; then
+            export XDG_RUNTIME_DIR="$(getconf DARWIN_USER_TEMP_DIR)"
+            export XDG_RUNTIME_DIR="''${XDG_RUNTIME_DIR%/}"
+          fi
 
+          if [[ -S "$XDG_RUNTIME_DIR/ssh-agent-mux.sock" ]]; then
+             export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent-mux.sock"
+          else
+             # Fallback: Initialize OnlyKey agent via keychain in the shell if service is not running
+             # This also ensures we have a fallback if the user disables the service but keeps this module
+             eval "$(${pkgs.keychain}/bin/keychain --eval --agents ssh id_ed25519_sk_rk -q)"
+          fi
+
+          # Link the current SSH_AUTH_SOCK to the standard location via .ssh/rc
+          if [[ -e "$HOME/.ssh/rc" ]]; then
             /bin/sh "$HOME/.ssh/rc"
-          )
-        else
-          eval "$(${pkgs.keychain}/bin/keychain --eval --agents ssh id_ed25519_sk_rk -q)"
+          fi
         fi
       '';
     })

--- a/modules/list.nix
+++ b/modules/list.nix
@@ -17,6 +17,7 @@
   neovim = ./programs/neovim;
   pet = ./programs/pet;
   rofi = ./programs/rofi;
+  secretive = ./programs/secretive;
   ssh = ./programs/ssh;
   starship = ./programs/starship.nix;
   termite = ./programs/termite.nix;
@@ -35,6 +36,7 @@
   sketchybar = ./services/sketchybar;
   skhd = ./services/skhd;
   sleep-on-lan = ./services/sleep-on-lan;
+  ssh-agent-mux = ./services/ssh-agent-mux;
   yabai = ./services/yabai;
 
   # settings

--- a/modules/programs/secretive/default.nix
+++ b/modules/programs/secretive/default.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  mode,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    optionals
+    ;
+
+  cfg = config.soxincfg.programs.secretive;
+in
+{
+  imports = optionals (mode == "home-manager") [ ./home.nix ];
+
+  options.soxincfg.programs.secretive = {
+    enable = mkEnableOption "the secretive SSH agent";
+  };
+}

--- a/modules/programs/secretive/home.nix
+++ b/modules/programs/secretive/home.nix
@@ -1,0 +1,18 @@
+{
+  config,
+  lib,
+  pkgs,
+  hostType,
+  ...
+}:
+
+let
+  inherit (lib) mkIf;
+
+  cfg = config.soxincfg.programs.secretive;
+in
+{
+  config = mkIf (cfg.enable && hostType == "nix-darwin") {
+    home.packages = [ pkgs.secretive ];
+  };
+}

--- a/modules/services/ssh-agent-mux/darwin.nix
+++ b/modules/services/ssh-agent-mux/darwin.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkIf;
+
+  cfg = config.soxincfg.services.ssh-agent-mux;
+
+  wrapper = pkgs.writeShellScript "ssh-agent-mux-start" ''
+    set -euo pipefail
+
+    # Ensure XDG_RUNTIME_DIR is set
+    if [[ -z "''${XDG_RUNTIME_DIR:-}" ]]; then
+       export XDG_RUNTIME_DIR="$(getconf DARWIN_USER_TEMP_DIR)"
+       export XDG_RUNTIME_DIR="''${XDG_RUNTIME_DIR%/}"
+    fi
+
+    # Initialize OnlyKey agent via keychain if available
+    eval "$(${pkgs.keychain}/bin/keychain --eval --agents ssh id_ed25519_sk_rk -q)"
+    ONLYKEY_AUTH_SOCK="$SSH_AUTH_SOCK"
+
+    # Persist the keychain info so other shells can use it if needed (though they should use the mux sock)
+    # keychain handles this by default in ~/.keychain
+
+    # Secretive agent socket location
+    SECRETIVE_AUTH_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+
+    ARGS=(
+      "-l" "$XDG_RUNTIME_DIR/ssh-agent-mux.sock"
+      "$SECRETIVE_AUTH_SOCK"
+      "$ONLYKEY_AUTH_SOCK"
+    )
+
+    # exec ssh-agent-mux
+    # Assuming ssh-agent-mux is installed in system packages or we use the specific package if available.
+    # Since it was added via patch, we might need to access it from pkgs.
+    exec ${pkgs.ssh-agent-mux}/bin/ssh-agent-mux "''${ARGS[@]}"
+  '';
+in
+{
+  config = mkIf cfg.enable {
+    # Install the package
+    environment.systemPackages = [ pkgs.ssh-agent-mux ];
+
+    launchd.user.agents.ssh-agent-mux = {
+      serviceConfig = {
+        Label = "net.ross-williams.ssh-agent-mux";
+        ProgramArguments = [ "${wrapper}" ];
+        KeepAlive = {
+          SuccessfulExit = false;
+        };
+        RunAtLoad = true;
+        # StandardOutPath = "/tmp/ssh-agent-mux.log"; # For debugging
+        # StandardErrorPath = "/tmp/ssh-agent-mux.err"; # For debugging
+      };
+    };
+  };
+}

--- a/modules/services/ssh-agent-mux/default.nix
+++ b/modules/services/ssh-agent-mux/default.nix
@@ -1,0 +1,17 @@
+{
+  config,
+  lib,
+  mode,
+  ...
+}:
+
+let
+  inherit (lib) mkEnableOption optionals;
+in
+{
+  imports = optionals (mode == "nix-darwin") [ ./darwin.nix ];
+
+  options.soxincfg.services.ssh-agent-mux = {
+    enable = mkEnableOption "ssh-agent-mux service";
+  };
+}

--- a/patches/ssh-agent-mux.patch
+++ b/patches/ssh-agent-mux.patch
@@ -1,0 +1,42 @@
+commit 28a74224af39610cfe8f631fe03d22131fa84027
+Author: Wael Nasreddine <wael.nasreddine@gmail.com>
+Date:   Sun Jan 18 14:44:18 2026 -0800
+
+    ssh-agent-mux: init at v0.2.0
+
+diff --git a/pkgs/by-name/ss/ssh-agent-mux/package.nix b/pkgs/by-name/ss/ssh-agent-mux/package.nix
+new file mode 100644
+index 000000000000..d33864f444bd
+--- /dev/null
++++ b/pkgs/by-name/ss/ssh-agent-mux/package.nix
+@@ -0,0 +1,30 @@
++{
++  lib,
++  fetchFromGitHub,
++  rustPlatform,
++  openssh,
++}:
++
++rustPlatform.buildRustPackage rec {
++  pname = "ssh-agent-mux";
++  version = "0.2.0";
++
++  src = fetchFromGitHub {
++    owner = "overhacked";
++    repo = "ssh-agent-mux";
++    rev = "v${version}";
++    hash = "sha256-tIGrENlZcT9fGke6MRnsLsmm+kb0Mm3C6DckkZi8hpE=";
++  };
++
++  cargoHash = "sha256-u5kGYCYDvEhSuGOLnhdt9IpRwzllXbSJDwY1XzpHBCc=";
++
++  nativeCheckInputs = [ openssh ];
++
++  meta = {
++    description = "A proxy that multiplexes SSH agent requests to multiple upstream agents";
++    homepage = "https://github.com/overhacked/ssh-agent-mux";
++    license = lib.licenses.asl20;
++    maintainers = [ lib.maintainers.kalbasit ];
++    mainProgram = "ssh-agent-mux";
++  };
++}


### PR DESCRIPTION
Use keychain for Onlykey SSH agent.
Use Secretive for Secure Enclave SSH.
Put ssh-agent-mux as a wrapper on top.