### PR TITLE
feat(steward): install and supervise the steward host agent

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,6 +201,27 @@
     "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
+          "steward",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788450739,
+        "narHash": "sha256-glZLQlzIn1fXH6PazR2iUmTo7kzzyYSshrWhLS9TqCU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "31729ca8cbdb4fa927b34e5f4353e6a83f39e993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_5": {
+      "inputs": {
+        "nixpkgs-lib": [
           "swm",
           "nixpkgs"
         ]
@@ -512,6 +533,22 @@
     },
     "nixpkgs_6": {
       "locked": {
+        "lastModified": 1788297115,
+        "narHash": "sha256-Z+vUNbfd2FIKkWOTkcT7RYlh3oFCnig/d2eXD1SWf2E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a3116115851d68b8952a2a4221cc25a84e56b532",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
         "lastModified": 1787698179,
         "narHash": "sha256-eakAr4YZKsQA0Pkd31Ef75dKgBMPCo4h9EVD3RjkWxg=",
         "owner": "NixOS",
@@ -686,6 +723,7 @@
         "pre-commit-hooks": "pre-commit-hooks_2",
         "sops-nix": "sops-nix",
         "soxin": "soxin",
+        "steward": "steward",
         "swm": "swm"
       }
     },
@@ -751,13 +789,33 @@
         "type": "github"
       }
     },
-    "swm": {
+    "steward": {
       "inputs": {
         "flake-parts": "flake-parts_4",
-        "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs_6",
-        "process-compose-flake": "process-compose-flake",
         "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1788583101,
+        "narHash": "sha256-DVWcjdd0Ng64YoOo/3Jc/FYnS5LnYYLJbKTHdhezJdk=",
+        "ref": "refs/heads/main",
+        "rev": "7bc2e4ecc1343b3daba76f4cf7ea0024b8d8911e",
+        "revCount": 41,
+        "type": "git",
+        "url": "ssh://git@github.com/kalbasit/steward"
+      },
+      "original": {
+        "type": "git",
+        "url": "ssh://git@github.com/kalbasit/steward"
+      }
+    },
+    "swm": {
+      "inputs": {
+        "flake-parts": "flake-parts_5",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs_7",
+        "process-compose-flake": "process-compose-flake",
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1787710847,
@@ -819,6 +877,27 @@
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "steward",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "swm",

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,15 @@
 
     swm.url = "github:kalbasit/swm";
 
+    # The steward host agent. Over ssh for the same reason as marketplace
+    # below: the repository is private, and the github: shorthand goes through
+    # the anonymous GitHub API and 404s on one.
+    #
+    # No `follows` on nixpkgs, matching swm above rather than marketplace: this
+    # is a Go binary consumed as a package, and its build is pinned against the
+    # nixpkgs its own flake locks.
+    steward.url = "git+ssh://git@github.com/kalbasit/steward";
+
     # Claude Code plugins. Over ssh rather than the github: shorthand, which
     # goes through the anonymous GitHub API and 404s on a private repository.
     marketplace = {

--- a/lib/mk-flake.nix
+++ b/lib/mk-flake.nix
@@ -66,6 +66,12 @@ let
             swm-full
             ;
 
+          # The host agent only. steward's flake also builds the server and its
+          # image, and neither belongs on a machine that merely runs work.
+          inherit (inputs.steward.packages.${super.stdenv.hostPlatform.system})
+            steward-agent
+            ;
+
           # direnv tests are failing on aarch64-darwin
           # https://github.com/NixOS/nixpkgs/issues/507531
           direnv = super.direnv.overrideAttrs (_: {

--- a/modules/list.nix
+++ b/modules/list.nix
@@ -21,6 +21,7 @@
   secretive = ./programs/secretive;
   ssh = ./programs/ssh;
   starship = ./programs/starship.nix;
+  steward = ./programs/steward;
   swm = ./programs/swm;
   termite = ./programs/termite.nix;
   tmux = ./programs/tmux;

--- a/modules/programs/steward/default.nix
+++ b/modules/programs/steward/default.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  mode,
+  pkgs,
+  ...
+}:
+
+{
+  imports = lib.optional (mode == "home-manager") ./home.nix;
+
+  options.soxincfg.programs.steward = {
+    enable = lib.mkEnableOption "the steward host agent";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.steward-agent;
+      defaultText = lib.literalExpression "pkgs.steward-agent";
+      description = ''
+        The package providing `steward-agent`.
+
+        Only the agent, never the server: a machine that runs work has no use
+        for the control plane it talks to.
+      '';
+    };
+
+    url = lib.mkOption {
+      type = lib.types.str;
+      example = "https://steward.nasreddine.com";
+      description = ''
+        The control plane's base URL.
+
+        Has no default. A wrong one is a host that looks configured and
+        registers with nothing, which is worse than a host that refuses to
+        start.
+      '';
+    };
+
+    credentialsFile = lib.mkOption {
+      type = lib.types.path;
+      example = lib.literalExpression ''config.sops.secrets."steward/env".path'';
+      description = ''
+        A file of `KEY=value` lines holding at least `STEWARD_TOKEN`, the
+        credential this host authenticates with.
+
+        Point this at a sops-nix secret. It is read at runtime and never copied
+        into the nix store.
+
+        Required, and deliberately not an option that can hold the token
+        directly. The agent itself refuses to read its token from a flag,
+        because a credential on a command line is visible in every process
+        listing on the machine — and a token written into a unit file would be
+        world-readable in the store, which is the same mistake one layer up.
+      '';
+    };
+
+    hostName = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        The name this host registers under. Null lets the agent use the
+        machine's hostname.
+
+        Set it when the machine's hostname is not stable — the name is how work
+        already placed here is found again after a restart, so a name that
+        changes strands that work on a host that no longer exists.
+      '';
+    };
+
+    labels = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = lib.literalExpression ''{ os = "linux"; location = "home"; }'';
+      description = ''
+        Labels describing this host, which the scheduler matches work against.
+
+        `reliability`, `capacity` and `name` are refused: each has its own
+        option, and a label shadowing one would be a second source for a value
+        that already has an answer.
+      '';
+    };
+
+    devices = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = lib.literalExpression ''[ "android" ]'';
+      description = ''
+        Resources physically attached to this machine, which work can require.
+
+        A device is a hard constraint rather than a preference: work needing
+        one will not be placed on a host without it, however idle that host is.
+      '';
+    };
+
+    reliability = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "always-on"
+          "intermittent"
+        ]
+      );
+      default = null;
+      description = ''
+        Whether this machine can be relied on to stay awake.
+
+        A laptop that sleeps is `intermittent`, and saying so is what stops
+        long work being placed on it. Null leaves the agent's own default.
+      '';
+    };
+
+    capacity = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.positive;
+      default = null;
+      description = ''
+        How many work items may run here at once. Null leaves the agent's
+        default of one.
+      '';
+    };
+
+    heartbeatInterval = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "30s";
+      description = ''
+        How often the agent reports liveness. Null leaves the agent's default.
+
+        A Go duration string, passed through unchanged — this is not a systemd
+        duration and is not converted.
+      '';
+    };
+  };
+}

--- a/modules/programs/steward/home.nix
+++ b/modules/programs/steward/home.nix
@@ -1,0 +1,110 @@
+{
+  config,
+  lib,
+  pkgs,
+  hostType,
+  ...
+}:
+
+let
+  cfg = config.soxincfg.programs.steward;
+
+  isDarwin = hostType == "nix-darwin";
+
+  reserved = [
+    "reliability"
+    "capacity"
+    "name"
+  ];
+  offending = lib.intersectLists reserved (lib.attrNames cfg.labels);
+
+  # The agent takes every setting from the environment, so the unit needs no
+  # arguments. STEWARD_TOKEN is deliberately absent: it comes from
+  # credentialsFile at runtime, never from here, because everything below lands
+  # in the world-readable nix store.
+  env = {
+    STEWARD_URL = cfg.url;
+  }
+  // lib.optionalAttrs (cfg.hostName != null) { STEWARD_HOST_NAME = cfg.hostName; }
+  // lib.optionalAttrs (cfg.labels != { }) {
+    STEWARD_LABELS = lib.concatStringsSep "," (lib.mapAttrsToList (k: v: "${k}=${v}") cfg.labels);
+  }
+  // lib.optionalAttrs (cfg.devices != [ ]) {
+    STEWARD_DEVICES = lib.concatStringsSep "," cfg.devices;
+  }
+  // lib.optionalAttrs (cfg.reliability != null) { STEWARD_RELIABILITY = cfg.reliability; }
+  // lib.optionalAttrs (cfg.capacity != null) { STEWARD_CAPACITY = toString cfg.capacity; }
+  // lib.optionalAttrs (cfg.heartbeatInterval != null) {
+    STEWARD_HEARTBEAT_INTERVAL = cfg.heartbeatInterval;
+  };
+
+  exe = lib.getExe cfg.package;
+in
+{
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = offending == [ ];
+            message =
+              "soxincfg.programs.steward.labels sets ${lib.concatStringsSep ", " offending}, "
+              + "which the control plane reserves. Each already has its own option, and a label "
+              + "shadowing one is a second source for a value that has one answer.";
+          }
+        ];
+
+        home.packages = [ cfg.package ];
+      }
+
+      # The agent is a supervised daemon rather than a timer. It holds one long
+      # subscription and is expected to outlive the server going away: a control
+      # plane that is down is a reconnect, not a reason for this machine to stop
+      # being part of the fleet. So it restarts always, and the agent itself
+      # exits only for a configuration it cannot use.
+      (lib.mkIf (!isDarwin) {
+        systemd.user.services.steward-agent = {
+          Unit = {
+            Description = "steward host agent: register this machine, report liveness, receive its work";
+            # Registering before the network is up fails, and the agent would
+            # rather reconnect than a unit flap at boot.
+            After = [ "network-online.target" ];
+            Wants = [ "network-online.target" ];
+          };
+
+          Service = {
+            Type = "simple";
+            ExecStart = exe;
+            Environment = lib.mapAttrsToList (k: v: "${k}=${v}") env;
+            EnvironmentFile = toString cfg.credentialsFile;
+            Restart = "always";
+            # Long enough that a genuinely broken configuration does not spin,
+            # short enough that a machine waking from sleep rejoins promptly.
+            RestartSec = "10s";
+          };
+
+          Install.WantedBy = [ "default.target" ];
+        };
+      })
+
+      (lib.mkIf isDarwin {
+        launchd.agents.steward-agent = {
+          enable = true;
+          config = {
+            # launchd has no EnvironmentFile, so the credentials are sourced by
+            # a shell instead. The token reaches the process through the
+            # environment either way and is never written to the store.
+            ProgramArguments = [
+              "/bin/sh"
+              "-c"
+              ". ${toString cfg.credentialsFile}; exec ${exe}"
+            ];
+            EnvironmentVariables = env;
+            RunAtLoad = true;
+            KeepAlive = true;
+          };
+        };
+      })
+    ]
+  );
+}


### PR DESCRIPTION
A machine only joins the steward fleet if something on it registers, reports liveness, and holds the subscription work arrives over. Nothing did — and steward's flake didn't even build the agent until [kalbasit/steward#3](https://github.com/kalbasit/steward/pull/3), so there was nothing to install.

## The input follows the marketplace precedent

Over `git+ssh://` rather than the `github:` shorthand, for the reason marketplace's own comment gives: the shorthand goes through the anonymous GitHub API and 404s on a private repository. steward is private.

It does **not** follow nixpkgs, matching `swm` rather than marketplace — this is a Go binary consumed as a package, and its build is pinned against the nixpkgs its own flake locks.

Only `steward-agent` is taken from that flake. It also builds the server and its OCI image, and a machine that runs work has no business carrying a control plane.

## A supervised daemon, not a timer

`Restart=always` on Linux, `KeepAlive` on Darwin. The agent holds one long subscription and is expected to outlive the server going away: a control plane that is down is a reconnect, not a reason for the host to stop being part of the fleet. The agent exits only for a configuration it cannot use, so restarting it forever is correct rather than a way to paper over crashes.

## The token is never written by this module

Everything else goes into the unit as environment. `STEWARD_TOKEN` comes from `credentialsFile` at runtime and appears in neither unit.

That is deliberate at two layers. The agent itself refuses to read its token from a flag, because a credential on a command line is visible in every process listing on the machine. A token written into a unit file would be world-readable in the nix store — the same mistake one layer up. There is intentionally no option that can hold the token directly.

## Guards

Labels shadowing `reliability`, `capacity` or `name` are refused by an assertion rather than silently losing to the dedicated option. Two sources for one value is a configuration that can disagree with itself.

## Verified

Evaluated the module for both host types rather than only parsing it:

- **Linux** renders `Type=simple`, `Restart=always`, `RestartSec=10s`, `EnvironmentFile=/run/secrets/…`, `WantedBy=default.target`, and `After`/`Wants` on `network-online.target`.
- **Darwin** renders `ProgramArguments` sourcing the credentials then `exec`, with `RunAtLoad` and `KeepAlive`.
- **Both** carry exactly six environment variables and **no token**.
- The reserved-label assertion fires with its intended message.

## Not enabled anywhere

No host turns this on. Doing so needs a real control-plane URL and a sops secret path, which belong to whoever owns the host rather than to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VJGwBshdbMSR6MPzCKu3n